### PR TITLE
fix: set polyjuice status default to be 'succeed'

### DIFF
--- a/utils/api/tx.ts
+++ b/utils/api/tx.ts
@@ -77,7 +77,7 @@ export const getTxRes = (tx: Raw): Parsed => ({
   hash: tx.hash,
   nonce: tx.nonce,
   status: tx.status ?? 'pending',
-  polyjuiceStatus: tx.polyjuice_status ?? 'pending',
+  polyjuiceStatus: tx.polyjuice_status ?? 'succeed',
   timestamp: tx.timestamp ? tx.timestamp * 1000 : -1,
   from: tx.from,
   to: tx.to,


### PR DESCRIPTION
Change default value of polyjuice status from 'pending' to
'succeed' since 'pending' will be returned explicitly but
null will be returned if tx is not of type polyjuice. In
this case the polyjuice status could be ignored or regarded
as succeed.

Ref: https://github.com/nervosnet/godwoken_explorer/issues/389