### PR TITLE
fix: remove redundant format on gas price

### DIFF
--- a/pages/tx/[hash].tsx
+++ b/pages/tx/[hash].tsx
@@ -238,11 +238,7 @@ const Tx = (initState: State) => {
     tx.gasPrice
       ? {
           label: 'gasPrice',
-          value: (
-            <Typography variant="body2">
-              {new BigNumber(tx.gasPrice).dividedBy(new BigNumber(CKB_DECIMAL)).toFormat() + ' CKB'}
-            </Typography>
-          ),
+          value: <Typography variant="body2">{new BigNumber(tx.gasPrice).toFormat() + ' CKB'}</Typography>,
         }
       : null,
     tx.gasUsed
@@ -262,10 +258,7 @@ const Tx = (initState: State) => {
           label: 'fee',
           value: (
             <Typography variant="body2">
-              {new BigNumber(tx.gasUsed)
-                .times(new BigNumber(tx.gasPrice))
-                .dividedBy(new BigNumber(CKB_DECIMAL))
-                .toFormat() + ' CKB'}
+              {new BigNumber(tx.gasUsed).times(new BigNumber(tx.gasPrice)).toFormat() + ' CKB'}
             </Typography>
           ),
         }


### PR DESCRIPTION
The gas price returned from API has been formatted and can
be displayed directly

Ref: https://github.com/nervosnet/godwoken_explorer/issues/361